### PR TITLE
revise PEPmeeting function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: PEPtools
 Title: Tools for Stock Assessment used by Population Ecology Program
-Version: 0.0.1.0000
+Version: 0.0.2.0000
 Authors@R: person("Kelli", "Johnson", email = "kelli.johnson@noaa.gov", role = c("aut", "cre"))
 Description: The package contains various tools that are useful to 
     scientists at the Northwest Fisheries Science Center (NWFSC)
@@ -14,11 +14,10 @@ Imports:
   r4ss,
   remotes,
   stats,
-  utils
-Remotes:
-  github::r4ss/r4ss@development
+  utils,
+  lubridate
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.0
 Roxygen: list(markdown = TRUE)

--- a/man/PEPmeeting.Rd
+++ b/man/PEPmeeting.Rd
@@ -2,29 +2,23 @@
 % Please edit documentation in R/PEPmeeting.R
 \name{PEPmeeting}
 \alias{PEPmeeting}
-\title{Generate Meeting Lead and Snack People}
+\title{Generate Meeting Lead and Scribe one year at a time}
 \usage{
 PEPmeeting(
-  date,
-  notattending = NA,
-  leads = c("Aaron", "Andi", "Brian", "Chantel", "Jason", "John", "Kelli", "Kristin",
-    "Ian", "Melissa", "Vlada"),
-  snacks = c("Kathryn")
+  year = format(Sys.time(), "\%Y"),
+  people = c("Aaron", "Andi", "Brian", "Chantel", "Jason", "John", "Kelli", "Kiva",
+    "Kristin", "Ian", "Melissa", "Vlada")
 )
 }
 \arguments{
-\item{date}{A numeric value giving the date of the meeting.}
+\item{year}{The year for which to generate the names. Defaults to the
+current year.}
 
-\item{notattending}{A vector of names of those not attending.}
-
-\item{leads}{A vector of potential leads.}
-
-\item{snacks}{A vector of people that can bring snacks but
-are not leads.}
+\item{people}{A vector of potential leads.}
 }
 \description{
-Generate Meeting Lead and Snack People
+Generate Meeting Lead and Scribe one year at a time
 }
 \examples{
-PEPtools::PEPmeeting(20200916, notattending=c("Owen", "Melissa"))
+PEPtools::PEPmeeting()
 }


### PR DESCRIPTION
This pull request completely rewrites `PEPmeeting()` to make it easier in the following ways:
- generate a table of lead and scribe assignments for the full year for pasting into the spreadsheet
- removes the `notattending` argument which wasn't reliable--we can continue to ask for volunteer replacements
- draws the lead and scribe from the same pool of people (but continue to avoid the same person in both roles)

Thanks @andi-stephens-NOAA for the inspiration to make these changes.

